### PR TITLE
Added support for chip silicon revision number

### DIFF
--- a/src/serialupdi.c
+++ b/src/serialupdi.c
@@ -122,7 +122,6 @@ static int serialupdi_decode_sib(const PROGRAMMER *pgm, updi_sib_info *sib_info)
   memset(sib_info->nvm_string, 0, SIB_INFO_NVM_LENGTH+1);
   memset(sib_info->debug_string, 0, SIB_INFO_DEBUG_LENGTH+1);
   memset(sib_info->pdi_string, 0, SIB_INFO_PDI_LENGTH+1);
-  memset(sib_info->pdi_string, 0, SIB_INFO_PDI_LENGTH+1);
   memset(sib_info->extra_string, 0, SIB_INFO_EXTRA_LENGTH+1);
 
   memcpy(sib_info->family_string, sib_info->sib_string, SIB_INFO_FAMILY_LENGTH);
@@ -631,6 +630,14 @@ static int serialupdi_initialize(const PROGRAMMER *pgm, const AVRPART *p) {
   if (serialupdi_decode_sib(pgm, sib_info) < 0) {
     pmsg_error("decode SIB_INFO failed\n");
     return -1;
+  }
+
+  if (updi_read_data(pgm, p->syscfg_base+1, &value, 1) < 0) {
+    pmsg_error("Reading chip silicon revision failed\n");
+    return -1;
+  } else {
+    pmsg_debug("Received chip silicon revision 0x%02x\n", value);
+    pmsg_notice("Chip silicon revision: %x.%x\n", value >> 4, value & 0x0f);
   }
 
   if (updi_link_init(pgm) < 0) {


### PR DESCRIPTION
Following your request, please find this PR with changed required to read and display chip silicon revision number. I tested it against AVR128DB28, ATmega4809 and some attiny chips that I had at hand. Sample outputs:

```
pymcuprog ping -t uart -u /dev/cu.usbserial-1410 -d atmega4809 -v info
Connecting to SerialUPDI
pymcuprog.programmer - INFO - Setting up programming session for 'atmega4809'
pymcuprog.deviceinfo.deviceinfo - INFO - Looking for device atmega4809
pymcuprog.serialupdi.physical - INFO - Opening port '/dev/cu.usbserial-1410' at 115200 baud (timeout 1.0s)
pymcuprog.serialupdi.link - INFO - UPDI init OK
pymcuprog.serialupdi.application - INFO - SIB: 'megaAVR P:0D:1-3M2 (01.59B20.0)'
pymcuprog.serialupdi.application - INFO - Device family ID: 'megaAVR'
pymcuprog.serialupdi.application - INFO - NVM interface: 'P:0'
pymcuprog.serialupdi.application - INFO - Debug interface: 'D:1'
pymcuprog.serialupdi.application - INFO - PDI oscillator: '3M2'
pymcuprog.serialupdi.application - INFO - Extra info: '(01.59B20.0)'
pymcuprog.serialupdi.application - INFO - NVM type 0: 16-bit, page oriented write
pymcuprog.serialupdi.application - INFO - PDI revision = 0x03
pymcuprog.serialupdi.application - INFO - Entering NVM programming mode
pymcuprog.serialupdi.application - INFO - Apply reset
pymcuprog.serialupdi.application - INFO - Release reset
Pinging device...
pymcuprog.programmer - INFO - Reading device ID...
pymcuprog.serialupdi.application - INFO - SIB: 'megaAVR P:0D:1-3M2 (01.59B20.0)'
pymcuprog.serialupdi.application - INFO - Device family ID: 'megaAVR'
pymcuprog.serialupdi.application - INFO - NVM interface: 'P:0'
pymcuprog.serialupdi.application - INFO - Debug interface: 'D:1'
pymcuprog.serialupdi.application - INFO - PDI oscillator: '3M2'
pymcuprog.serialupdi.application - INFO - Extra info: '(01.59B20.0)'
pymcuprog.serialupdi.application - INFO - NVM type 0: 16-bit, page oriented write
pymcuprog.serialupdi.application - INFO - PDI revision = 0x03
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.serialupdi.application - INFO - Device ID from serialupdi = '1E9651' rev 'B'
pymcuprog.nvm - INFO - Device family: 'megaAVR'
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.nvm - INFO - Device ID: '1E9651'
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.nvm - INFO - Device revision: '0.1'
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.nvm - INFO - Device serial number: 'b'515052384e2044342d0c''
Ping response: 1E9651
pymcuprog.serialupdi.application - INFO - Leaving NVM programming mode
pymcuprog.serialupdi.application - INFO - Apply reset
pymcuprog.serialupdi.application - INFO - Release reset
```

```
./avrdude -c serialupdi -P /dev/cu.usbserial-1410 -p m4809 -v

avrdude: Version 7.0-20220508
         Copyright the AVRDUDE authors;
         see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

         System wide configuration file is /Users/dawid/Development/avrdude/build_darwin/src/avrdude.conf
         User configuration file is /Users/dawid/.avrduderc
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : /dev/cu.usbserial-1410
         Using Programmer              : serialupdi
         AVR Part                      : ATmega4809
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           fuse0       wdtcfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse1       bodcfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2       osccfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5       syscfg0     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse6       syscfg1     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse7       append      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse8       bootend     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuses                   0     0     0    0 no          9   10      0     0     0 0x00 0x00
           lock                    0     0     0    0 no          1    1      0     0     0 0x00 0x00
           tempsense               0     0     0    0 no          2    1      0     0     0 0x00 0x00
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig                 0     0     0    0 no         61   61      0     0     0 0x00 0x00
           sernum                  0     0     0    0 no         10    1      0     0     0 0x00 0x00
           osccal16                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           osccal20                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           osc16err                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           osc20err                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           data                    0     0     0    0 no          0    1      0     0     0 0x00 0x00
           userrow     usersig     0     0     0    0 no         64   64      0     0     0 0x00 0x00
           eeprom                  0     0     0    0 no        256   64      0     0     0 0x00 0x00
           flash                   0     0     0    0 no      49152  128      0     0     0 0x00 0x00

         Programmer Type : serialupdi
         Description     : SerialUPDI
avrdude: NVM type 0: 16-bit, page oriented write
avrdude: Chip silicon revision: 0.1
avrdude: entering NVM programming mode
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9651 (probably m4809)
avrdude: leaving NVM programming mode

avrdude done.  Thank you.
```

```
pymcuprog ping -t uart -u /dev/cu.usbserial-1410 -d avr128db28 -v info
Connecting to SerialUPDI
pymcuprog.programmer - INFO - Setting up programming session for 'avr128db28'
pymcuprog.deviceinfo.deviceinfo - INFO - Looking for device avr128db28
pymcuprog.serialupdi.physical - INFO - Opening port '/dev/cu.usbserial-1410' at 115200 baud (timeout 1.0s)
pymcuprog.serialupdi.link - INFO - UPDI init OK
pymcuprog.serialupdi.application - INFO - SIB: 'AVR     P:2D:1-3M2 (A5.KV00D.0)'
pymcuprog.serialupdi.application - INFO - Device family ID: 'AVR'
pymcuprog.serialupdi.application - INFO - NVM interface: 'P:2'
pymcuprog.serialupdi.application - INFO - Debug interface: 'D:1'
pymcuprog.serialupdi.application - INFO - PDI oscillator: '3M2'
pymcuprog.serialupdi.application - INFO - Extra info: '(A5.KV00D.0)'
pymcuprog.serialupdi.application - INFO - NVM type 2: 24-bit, word oriented write
pymcuprog.serialupdi.link - INFO - UPDI init OK
pymcuprog.serialupdi.application - INFO - PDI revision = 0x03
pymcuprog.serialupdi.application - INFO - Entering NVM programming mode
pymcuprog.serialupdi.application - INFO - Apply reset
pymcuprog.serialupdi.application - INFO - Release reset
Pinging device...
pymcuprog.programmer - INFO - Reading device ID...
pymcuprog.serialupdi.application - INFO - SIB: 'AVR     P:2D:1-3M2 (A5.KV00D.0)'
pymcuprog.serialupdi.application - INFO - Device family ID: 'AVR'
pymcuprog.serialupdi.application - INFO - NVM interface: 'P:2'
pymcuprog.serialupdi.application - INFO - Debug interface: 'D:1'
pymcuprog.serialupdi.application - INFO - PDI oscillator: '3M2'
pymcuprog.serialupdi.application - INFO - Extra info: '(A5.KV00D.0)'
pymcuprog.serialupdi.application - INFO - NVM type 2: 24-bit, word oriented write
pymcuprog.serialupdi.link - INFO - UPDI init OK
pymcuprog.serialupdi.application - INFO - PDI revision = 0x03
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.serialupdi.application - INFO - Device ID from serialupdi = '1E970E' rev 'V'
pymcuprog.nvm - INFO - Device family: 'AVR'
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.nvm - INFO - Device ID: '1E970E'
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.nvm - INFO - Device revision: '1.5'
pymcuprog.serialupdi.link - INFO - ST to ptr
pymcuprog.nvm - INFO - Device serial number: 'b'ff0904820dffffffffff''
Ping response: 1E970E
pymcuprog.serialupdi.application - INFO - Leaving NVM programming mode
pymcuprog.serialupdi.application - INFO - Apply reset
pymcuprog.serialupdi.application - INFO - Release reset
```

```
./avrdude -c serialupdi -P /dev/cu.usbserial-1410 -p avr128db28 -v

avrdude: Version 7.0-20220508
         Copyright the AVRDUDE authors;
         see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

         System wide configuration file is /Users/dawid/Development/avrdude/build_darwin/src/avrdude.conf
         User configuration file is /Users/dawid/.avrduderc
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : /dev/cu.usbserial-1410
         Using Programmer              : serialupdi
         AVR Part                      : AVR128DB28
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           fuse0       wdtcfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse1       bodcfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2       osccfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5       syscfg0     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse6       syscfg1     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse7       codesize    0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse8       bootsize    0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuses                   0     0     0    0 no          9   16      0     0     0 0x00 0x00
           lock                    0     0     0    0 no          4    1      0     0     0 0x00 0x00
           tempsense               0     0     0    0 no          2    1      0     0     0 0x00 0x00
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig                 0     0     0    0 no        125  125      0     0     0 0x00 0x00
           sernum                  0     0     0    0 no         16    1      0     0     0 0x00 0x00
           userrow     usersig     0     0     0    0 no         32   32      0     0     0 0x00 0x00
           data                    0     0     0    0 no          0    1      0     0     0 0x00 0x00
           eeprom                  0     0     0    0 no        512    1      0     0     0 0x00 0x00
           flash                   0     0     0    0 no     131072  512      0     0     0 0x00 0x00

         Programmer Type : serialupdi
         Description     : SerialUPDI
avrdude: NVM type 2: 24-bit, word oriented write
avrdude: Chip silicon revision: 1.5
avrdude: entering NVM programming mode
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e970e (probably avr128db28)
avrdude: leaving NVM programming mode

avrdude done.  Thank you.
```